### PR TITLE
응답객체 통일과 커스텀 응답객체들을 위한 apiresponse 개발

### DIFF
--- a/src/main/java/com/ohho/valetparking/domains/parking/controller/TicketController.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/controller/TicketController.java
@@ -2,7 +2,9 @@ package com.ohho.valetparking.domains.parking.controller;
 
 import com.ohho.valetparking.domains.parking.entity.Ticket;
 import com.ohho.valetparking.domains.parking.dto.TicketReqeust;
+import com.ohho.valetparking.domains.parking.exception.TicketDuplicateException;
 import com.ohho.valetparking.domains.parking.service.TicketService;
+import com.ohho.valetparking.global.common.dto.ApiResponse;
 import com.ohho.valetparking.global.security.JWTProvider;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
@@ -26,7 +29,7 @@ public class TicketController {
     private final TicketService ticketService;
 
     @PostMapping(value = "/ticket", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity ticketRegister(@RequestBody @Valid TicketReqeust ticketReqeust, HttpServletRequest request){
+    public ApiResponse<Ticket> ticketRegister(@RequestBody @Valid TicketReqeust ticketReqeust, HttpServletRequest request){
         log.info("TicketController ticketReqeust ::::: = {} ",ticketReqeust);
         Ticket ticketIncludedEmail = ticketReqeust.toTicket(
                                         JWTProvider.getEmailInFromToken(
@@ -36,13 +39,24 @@ public class TicketController {
 
         ticketService.register(ticketIncludedEmail);
 
-        return ResponseEntity.status(HttpStatus.OK)
-                             .body("티켓등록 성공");
+        return ApiResponse.success(ticketIncludedEmail);
     }
 
     @GetMapping(value = "/ticket/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity ticketInformation(@PathVariable("id") final String id) {
-        return ResponseEntity.status(HttpStatus.OK)
-                             .body(id);
+        return ResponseEntity.status(HttpStatus.OK).body(id);
+    }
+
+
+    @ApiIgnore
+    @GetMapping(value = "/ticket/test/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApiResponse<String> ticketInformationTest(@PathVariable("id") final String id) {
+        TicketDuplicateException ticketDuplicateException = new TicketDuplicateException("티켓이 중복입니다.");
+
+        if(id.equals("1")) {
+            return ApiResponse.fail("C200",ticketDuplicateException.getMessage(),HttpStatus.BAD_REQUEST);
+        }
+
+        return ApiResponse.success(id);
     }
 }

--- a/src/main/java/com/ohho/valetparking/global/common/CommonResponse.java
+++ b/src/main/java/com/ohho/valetparking/global/common/CommonResponse.java
@@ -1,0 +1,13 @@
+package com.ohho.valetparking.global.common;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Role :
+ * Responsibility :
+ * Cooperation with :
+ **/
+public class CommonResponse {
+    public static final ResponseEntity SUECCESS_RESPONSE = ResponseEntity.status(HttpStatus.OK).build();
+}

--- a/src/main/java/com/ohho/valetparking/global/common/dto/ApiResponse.java
+++ b/src/main/java/com/ohho/valetparking/global/common/dto/ApiResponse.java
@@ -1,0 +1,62 @@
+package com.ohho.valetparking.global.common.dto;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Role : 모든 반환 값을 대신한다.
+ * Responsibility :
+ * 내부에 errorResponse를 등록해야할 것인가에 대한 고민이 더 필요
+ * httpstatus는 스프링에 종속 적이다. 그래서 code와 status의 경우는 그냥 만들어서 사용
+ * success는 그냥 200 ok이다.
+ **/
+@ToString
+@Getter
+@EqualsAndHashCode
+public class ApiResponse<T> {
+    @DateTimeFormat(pattern = "yyyy-MM-dd 'T'HH:mm")
+    private final String localDateTime;
+    private final boolean success;
+    private final T data;
+    private final ErrorResponse errorResponse;
+
+    public ApiResponse(boolean success, T data, ErrorResponse errorResponse) {
+        localDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        this.success = success;
+        this.data = data;
+        this.errorResponse = errorResponse;
+    }
+
+    public static <T> ApiResponse success(T data) {
+        return new ApiResponse(true, data, null);
+    }
+
+    public static <T> ApiResponse fail(String code, String message ,HttpStatus httpStatus) {
+        return new ApiResponse(false, null, new ErrorResponse(code, message, httpStatus));
+    }
+    @ToString
+    @Getter
+    @EqualsAndHashCode
+    public static class ErrorResponse {
+        @DateTimeFormat(pattern = "yyyy-MM-dd 'T'HH:mm")
+        private final String localDateTime;
+        private final String code;
+        private final String message;
+        private final HttpStatus status;
+
+        public ErrorResponse(String code, String message, HttpStatus status) {
+            localDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+            this.code = code;
+            this.message = message;
+            this.status = status;
+
+        }
+    }
+}
+

--- a/src/main/java/com/ohho/valetparking/global/error/ErrorCode.java
+++ b/src/main/java/com/ohho/valetparking/global/error/ErrorCode.java
@@ -17,9 +17,9 @@ public enum ErrorCode {
 
     // Member
     EMAIL_DUPLICATION(400, "M001", "Email is Duplication"),
-    LOGIN_INPUT_INVALID(400, "M002", "Login input is invalid"),
+    LOGIN_INPUT_INVALID(400, "M002", "Login input is invalid")
 
-            ;
+    ;
     private final String code;
     private final String message;
     private int status;

--- a/src/main/java/com/ohho/valetparking/global/error/ErrorResponse.java
+++ b/src/main/java/com/ohho/valetparking/global/error/ErrorResponse.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Getter // 시리얼라이즈가 필요한 객체일 경우에는 Getter 메서드가 꼭 필요하다.
 @ToString
-public class ErrorResponse implements Serializable {
+public class ErrorResponse {
     @DateTimeFormat(pattern = "yyyy-MM-dd 'T'HH:mm:ss")
     private final String localDateTime;
     private final String code;

--- a/src/test/java/com/ohho/valetparking/global/common/DtoTest.java
+++ b/src/test/java/com/ohho/valetparking/global/common/DtoTest.java
@@ -1,0 +1,63 @@
+package com.ohho.valetparking.global.common;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ohho.valetparking.domains.member.exception.SignUpFailException;
+import com.ohho.valetparking.domains.parking.controller.TicketController;
+import com.ohho.valetparking.domains.parking.dto.TicketReqeust;
+import com.ohho.valetparking.domains.parking.entity.Ticket;
+import com.ohho.valetparking.domains.parking.service.TicketService;
+import com.ohho.valetparking.global.common.dto.ApiResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Role :
+ * Responsibility :
+ * Cooperation with :
+ **/
+
+@WebMvcTest(controllers = TicketController.class
+            , excludeAutoConfiguration = SecurityAutoConfiguration.class )
+public class DtoTest {
+
+    @Test
+    void apiresponse_성공_테스트() throws JsonProcessingException {
+    // given
+        Ticket ticket = Ticket.builder(new TicketReqeust(245,"1234","test",""),"test@gamil.com").build();
+        ApiResponse apiResponse = ApiResponse.success(ticket);
+        ObjectMapper objectMapper = new ObjectMapper();
+    // when
+        String jsontest = objectMapper.writeValueAsString(apiResponse);
+        String test = jsontest.substring(jsontest.indexOf(','));
+
+        // then
+        Assertions.assertThat(jsontest).isEqualTo("{\"localDateTime" + "\":\"" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))+ "\"" + test);
+    }
+
+    @Test
+    void apiresponse_실패_테스트() throws JsonProcessingException {
+    // given
+        Ticket ticket = Ticket.builder(new TicketReqeust(245,"1234","test",""),"test@gamil.com").build();
+        SignUpFailException signUpFailException = new SignUpFailException("this is test ");
+        ApiResponse apiResponse = ApiResponse.fail("B201",signUpFailException.getMessage(), HttpStatus.BAD_REQUEST);
+        ObjectMapper objectMapper = new ObjectMapper();
+    // when
+          String jsontest = objectMapper.writeValueAsString(apiResponse);
+          String test = jsontest.substring(jsontest.indexOf(','));
+    // then
+        System.out.println(jsontest);
+        Assertions.assertThat(jsontest).isEqualTo("{\"localDateTime" + "\":\"" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))+ "\"" + test);
+    }
+
+
+}

--- a/src/test/java/com/ohho/valetparking/parking/TicketControllerTest.java
+++ b/src/test/java/com/ohho/valetparking/parking/TicketControllerTest.java
@@ -17,6 +17,11 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -29,11 +34,25 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class TicketControllerTest {
     @Autowired
     private MockMvc mockMvc;
+
     @Autowired
     private ObjectMapper objectMapper;
+
     @MockBean
     private TicketService ticketService;
 
+
+    @Test
+    void apiresponseTest() throws Exception{
+        // given
+        final TicketReqeust ticketReqeust = new TicketReqeust(1234,"","B201","테스트");
+        // when
+          mockMvc.perform(MockMvcRequestBuilders.get("/ticket/test/3")
+                        .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(content().string("{\"localDateTime" + "\":\"" + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")) + "\"" + ",\"success\":true,\"data\":\"3\",\"errorResponse\":null}"))
+                        .andDo(print());
+
+    }
     @Test
     void 파킹_티켓_추가_실패_statusTest() throws Exception{
     // given


### PR DESCRIPTION
### Notify
@Sansho

### Motivation
프론트엔드에서 응답을 받을 때 일관된 형태로 받을 수 있게 응답객체를 요청했습니다. 현재 ResponseEntity를 통한 응답객체로도 충분히 통일이 가능하지만 나중을 위해 하나의 객체를 생성해 놓았습니다.

### Test plan
단위테스트를 모두 통과했습니다. 단위 테스트의 경우 apiresponse가 생성되는 시점에 성공과 실패를 결정하는 두가지 케이스를 테스트 했습니다.

누락된 테스트 케이스가 존재한다면 알려주시기 바랍니다.

### Commits
TicketController.java
CommonResponse.java
dto/ApiResponse.java
ErrorCode.java
ErrorResponse.java
DtoTest.java
TicketControllerTest.java