### PR TITLE
주차기록 전체 조회 api

### DIFF
--- a/src/main/java/com/ohho/valetparking/domains/parking/controller/ParkingController.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/controller/ParkingController.java
@@ -1,5 +1,6 @@
 package com.ohho.valetparking.domains.parking.controller;
 
+import com.ohho.valetparking.domains.parking.entity.Parking;
 import com.ohho.valetparking.domains.parking.entity.ParkingCount;
 import com.ohho.valetparking.domains.parking.service.ParkingService;
 import com.ohho.valetparking.global.common.dto.SuccessResponse;
@@ -27,10 +28,8 @@ public class ParkingController {
 
     @GetMapping("/parkings")
     public ResponseEntity getParkingList(){
-        List list =new ArrayList();
-        list.add("ParkingList : 리스트로 갈꺼야");
-        //현재 주차된 차량 정보 모두 조회 후 반환
-        return ResponseEntity.status(HttpStatus.OK).body(list);
+        List<Parking> parkings = parkingService.getParkingRecordList();
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.success(parkings));
     }
 
     @GetMapping("/parking-count")

--- a/src/main/java/com/ohho/valetparking/domains/parking/entity/Parking.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/entity/Parking.java
@@ -1,0 +1,36 @@
+package com.ohho.valetparking.domains.parking.entity;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.Date;
+
+/**
+ * Role :
+ * Responsibility :
+ * Cooperation with :
+ **/
+@Getter
+@ToString
+@EqualsAndHashCode
+@AllArgsConstructor
+public class Parking {
+
+    private final long parkingId;
+    private final String vipName;
+    private final long ticketNumber;
+    private final String carNumber;
+    private final String parkingArea;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime entranceAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime exitAt;
+    private final int status;
+
+}

--- a/src/main/java/com/ohho/valetparking/domains/parking/exception/ParkingRecordNotFoundException.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/exception/ParkingRecordNotFoundException.java
@@ -1,0 +1,13 @@
+package com.ohho.valetparking.domains.parking.exception;
+
+/**
+ * Role :
+ * Responsibility :
+ * Cooperation with :
+ **/
+public class ParkingRecordNotFoundException extends RuntimeException {
+    public ParkingRecordNotFoundException(){}
+    public ParkingRecordNotFoundException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/ohho/valetparking/domains/parking/repository/ParkingMapper.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/repository/ParkingMapper.java
@@ -1,5 +1,6 @@
 package com.ohho.valetparking.domains.parking.repository;
 
+import com.ohho.valetparking.domains.parking.entity.Parking;
 import com.ohho.valetparking.domains.parking.entity.ParkingCount;
 import org.apache.ibatis.annotations.Mapper;
 import org.springframework.stereotype.Repository;
@@ -14,4 +15,5 @@ public interface ParkingMapper {
 
     int parkingRegister(HashMap<String,Long> parkingInfo);
     List<ParkingCount> getParkingCount();
+    List<Parking> getParkingRecordList();
 }

--- a/src/main/java/com/ohho/valetparking/domains/parking/service/ParkingService.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/service/ParkingService.java
@@ -1,12 +1,14 @@
 package com.ohho.valetparking.domains.parking.service;
 
+import com.ohho.valetparking.domains.parking.entity.Parking;
 import com.ohho.valetparking.domains.parking.entity.ParkingCount;
+import com.ohho.valetparking.domains.parking.exception.ParkingRecordNotFoundException;
 import com.ohho.valetparking.domains.parking.repository.ParkingMapper;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Role :
@@ -14,11 +16,31 @@ import java.util.List;
  * Cooperation with :
  **/
 @Service
-@AllArgsConstructor
 @Slf4j
 public class ParkingService {
     private final ParkingMapper parkingMapper;
+
+    public ParkingService(ParkingMapper parkingMapper) {
+        assert parkingMapper != null;
+        this.parkingMapper = parkingMapper;
+    }
+
     public List<ParkingCount> getParkingCount() {
         return parkingMapper.getParkingCount();
+    }
+
+    public List<Parking> getParkingRecordList() {
+
+        // 만약 중간에 빈데이터가 있을 경우 필터링
+        List<Parking> list = parkingMapper.getParkingRecordList()
+                                          .stream()
+                                          .filter(x -> x.getCarNumber() != null)
+                                          .collect(Collectors.toList());
+
+        if(list.size() == 0 || list == null) {
+            throw new ParkingRecordNotFoundException("주차 기록이 존재하지 않습니다.");
+        }
+
+        return list;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
       matching-strategy: ant_path_matcher
 
   datasource:
-        url: jdbc:mysql://${VALET_DB_URL}:${VALET_DB_PORT}/easyvalet?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false
+        url: jdbc:mysql://${VALET_DB_URL}:${VALET_DB_PORT}/easyvalet?characterEncoding=UTF-8&serverTimezone=UTC&useSSL=false&zeroDateTimeBehavior=convertToNull
         username: ${VALET_DB_USERNAME}
         password: ${VALET_DB_PASSWORD}
         driver-class-name: com.mysql.cj.jdbc.Driver
@@ -37,3 +37,5 @@ mybatis:
   config: mybatis-config.xml
   type-aliases-package: com.ohho.valetparking.domains.*
   mapper-locations: mybatis/mapper/*/*.xml
+  configuration:
+    map-underscore-to-camel-case: true

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -2,7 +2,9 @@
 <!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-config.dtd">
 <configuration>
-    <mappers>
-        <mapper resource="VipMapper.xml"/>
-    </mappers>
+    <settings>
+        <setting name="mapUnderscoreToCamelCase" value="true"/>
+        <setting name="callSettersOnNulls" value="true"/>
+        <setting name="jdbcTypeForNull" value="NULL"/>
+    </settings>
 </configuration>

--- a/src/main/resources/mybatis/mapper/parking/ParkingMapper.xml
+++ b/src/main/resources/mybatis/mapper/parking/ParkingMapper.xml
@@ -39,5 +39,22 @@
         GROUP BY B.parking_area
     </select>
 
+    <select id="getParkingRecordList" resultType="com.ohho.valetparking.domains.parking.entity.Parking">
+        SELECT
+            pr.id as parking_id
+            ,v.name as vip_name
+            ,t.ticket_number
+            ,t.car_number
+            ,t.parking_area
+            ,pr.entrance_at
+            ,pr.exit_at
+            ,pr.status
+        FROM parking_record pr LEFT OUTER JOIN ticket t
+                     ON pr.ticket_id = t.id
+                                LEFT OUTER JOIN vip v
+                     ON pr.vip_id = v.id
+        ORDER BY entrance_at
+    </select>
+
 
 </mapper>

--- a/src/test/java/com/ohho/valetparking/global/common/DtoTest.java
+++ b/src/test/java/com/ohho/valetparking/global/common/DtoTest.java
@@ -28,13 +28,10 @@ import java.time.format.DateTimeFormatter;
 @WebMvcTest(controllers = TicketController.class
             , excludeAutoConfiguration = SecurityAutoConfiguration.class )
 public class DtoTest {
-
     @MockBean
     private TicketService ticketService;
-
     @MockBean
     private JWTProvider jwtProvider;
-
     @Test
     void apiresponse_성공_테스트() throws JsonProcessingException {
     // given

--- a/src/test/java/com/ohho/valetparking/global/common/PropertyInjectionTest.java
+++ b/src/test/java/com/ohho/valetparking/global/common/PropertyInjectionTest.java
@@ -22,11 +22,9 @@ import org.springframework.test.context.TestPropertySource;
 @SpringBootTest
 @TestPropertySource(properties = { "spring.config.location=classpath:application.yml" })
 public class PropertyInjectionTest {
-    private  String SECREAT_KEY;
-
-    private  int ONEWEEK;
-
-    private  int ONEHOUR;
+    private String SECREAT_KEY;
+    private int ONEWEEK;
+    private int ONEHOUR;
 
     @Value("${secretKey}")
     public void setSecreatKey(String secreatKey) {

--- a/src/test/java/com/ohho/valetparking/parking/ParkingServiceTest.java
+++ b/src/test/java/com/ohho/valetparking/parking/ParkingServiceTest.java
@@ -1,0 +1,50 @@
+package com.ohho.valetparking.parking;
+
+import com.ohho.valetparking.domains.parking.entity.Parking;
+import com.ohho.valetparking.domains.parking.exception.ParkingRecordNotFoundException;
+import com.ohho.valetparking.domains.parking.repository.ParkingMapper;
+import com.ohho.valetparking.domains.parking.service.ParkingService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.parameters.P;
+
+import java.lang.reflect.Method;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Role :
+ * Responsibility :
+ * Cooperation with :
+ **/
+
+@ExtendWith(MockitoExtension.class)
+public class ParkingServiceTest {
+    @Mock
+    ParkingService parkingService;
+
+    @Test
+    @DisplayName("주차 기록 전체 조회")
+    void testGetParkingList(){
+    // given
+        List<Parking> parkingList = new ArrayList<>();
+        parkingList.add(
+                new Parking(123,"권재현",2345,"2341"
+                            ,"M2", LocalDateTime.now(),LocalDateTime.now(),0));
+    // when
+        Mockito.when(parkingService.getParkingRecordList()).thenReturn(parkingList);
+        int size = parkingService.getParkingRecordList().size();
+    // then
+        assertThat(1).isEqualTo(size);
+    }
+}


### PR DESCRIPTION
### Notify
@Sancho

### Summary
주차 기록 전체 조회 기능

### Motivation
프론트에서 현재까지의 주차 기록들과 현재 주차 상태들을 보여줄 수 있는 데이터 반환요청을 받았습니다.

### Description
모든 parking record들을 가져오기 때문에 restful하게 GET 메서드를 사용하였고 url의 target resource 같은 경우에 /parkings로 지정하였습니다.

요청이 들어오면 디비에서 해당 데이터들을 최신순으로 정렬하여 반환합니다. 데이터가 아예 비어있는 기록이 조회될 경우 필터링을 통해 비어있지 않은 데이터들만 반환합니다. 만약 데이터가 아예 존재하지 않으면 ParkingRecordNotFoundException을 발생 시키고 해당 오류에 대한 메세지를 반환해줍니다. 

Mybatis에서 LocalDateTime을 사용할 때 제대로된 날짜로 json parsing이 되지 않는 이슈가 발생 Jackson이나 Gson의 annotation을 사용하여 포맷을 정해줄 수 있습니다.

### Commits
ParkingController.java
Parking.java
ParkingRecordNotFoundException.java
ParkingMapper.java
ParkingService.java
application.yml
mybatis-config.xml
ParkingMapper.xml