### PR TITLE
주차 기록 단건 조회 API

### DIFF
--- a/src/main/java/com/ohho/valetparking/domains/parking/controller/ParkingController.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/controller/ParkingController.java
@@ -7,8 +7,10 @@ import com.ohho.valetparking.global.common.dto.SuccessResponse;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
@@ -26,13 +28,24 @@ public class ParkingController {
 
     private final ParkingService parkingService;
 
-    @GetMapping("/parkings")
-    public ResponseEntity getParkingList(){
+    @GetMapping(value = "/parkings", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<SuccessResponse> getParkingList(){
         List<Parking> parkings = parkingService.getParkingRecordList();
-        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.success(parkings));
+
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(SuccessResponse.success(parkings));
     }
 
-    @GetMapping("/parking-count")
+    @GetMapping(value = "/parking/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<SuccessResponse> getParking(@PathVariable long id){
+
+        Parking parking = parkingService.getParkingRecord(id);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(SuccessResponse.success(parking));
+    }
+
+    @GetMapping(value = "/parking-count", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<SuccessResponse> getParkingCount(){
         List<ParkingCount> parkingCount = parkingService.getParkingCount();
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/ohho/valetparking/domains/parking/repository/ParkingMapper.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/repository/ParkingMapper.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 
 @Repository
@@ -16,4 +17,5 @@ public interface ParkingMapper {
     int parkingRegister(HashMap<String,Long> parkingInfo);
     List<ParkingCount> getParkingCount();
     List<Parking> getParkingRecordList();
+    Optional<Parking> getParkingRecord(long id);
 }

--- a/src/main/java/com/ohho/valetparking/domains/parking/service/ParkingService.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/service/ParkingService.java
@@ -47,4 +47,11 @@ public class ParkingService {
 
         return list;
     }
+
+    public Parking getParkingRecord(long id) {
+        log.info("[ParkingService] ::::: id ={} " , id);
+        Parking parking = parkingMapper.getParkingRecord(id)
+                                       .orElseThrow(() -> new ParkingRecordNotFoundException("해당 기록을 찾울 수 없습니다."));
+        return parking;
+    }
 }

--- a/src/main/java/com/ohho/valetparking/global/Interceptor/AuthLoginInterceptor.java
+++ b/src/main/java/com/ohho/valetparking/global/Interceptor/AuthLoginInterceptor.java
@@ -1,6 +1,7 @@
 package com.ohho.valetparking.global.Interceptor;
 
 import com.ohho.valetparking.domains.member.exception.SignUpFailException;
+import com.ohho.valetparking.global.error.exception.TokenExpiredException;
 import com.ohho.valetparking.global.security.JWTProvider;
 import io.jsonwebtoken.Jwt;
 import lombok.AllArgsConstructor;
@@ -39,14 +40,14 @@ public class AuthLoginInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String refreshToken = request.getHeader("REFRESHTOKEN");
+//        String refreshToken = request.getHeader("REFRESHTOKEN");
+//
+//
+//        if ( refreshToken != null && jwtProvider.isValid(refreshToken)){
+//            // 리프레시토큰에서 회원정보(아이디,부서)얻어오기
+//            response.setHeader("ACCESSTOKEN",jwtProvider.accessTokenCreate(jwtProvider.getEmailInFromToken(refreshToken)));
+//        }
 
-
-        if ( refreshToken != null && jwtProvider.isValid(refreshToken)){
-            // 리프레시토큰에서 회원정보(아이디,부서)얻어오기
-            response.setHeader("ACCESSTOKEN",jwtProvider.accessTokenCreate(jwtProvider.getEmailInFromToken(refreshToken)));
-        }
-
-        throw new IllegalAccessException("유효하지 않은 토큰입니다.");
+        throw new TokenExpiredException("유효하지 않은 토큰입니다.");
     }
 }

--- a/src/main/java/com/ohho/valetparking/global/configuration/InterceptorConfiguration.java
+++ b/src/main/java/com/ohho/valetparking/global/configuration/InterceptorConfiguration.java
@@ -16,13 +16,13 @@ public class InterceptorConfiguration implements WebMvcConfigurer {
     private final AuthLoginInterceptor authLoginInterceptor;
 
     public InterceptorConfiguration(AuthLoginInterceptor authLoginInterceptor) {
+        assert authLoginInterceptor != null;
         this.authLoginInterceptor = authLoginInterceptor;
     }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authLoginInterceptor)
-                .addPathPatterns("*")
                 .excludePathPatterns("/member/*")
                 .excludePathPatterns("/swagger-ui/*")
                 .excludePathPatterns("/ticket")

--- a/src/main/resources/mybatis/mapper/parking/ParkingMapper.xml
+++ b/src/main/resources/mybatis/mapper/parking/ParkingMapper.xml
@@ -56,5 +56,23 @@
         ORDER BY entrance_at
     </select>
 
+    <select id="getParkingRecord" resultType="com.ohho.valetparking.domains.parking.entity.Parking" parameterType="long">
+        SELECT
+            pr.id as parking_id
+            ,v.name as vip_name
+            ,t.ticket_number
+            ,t.car_number
+            ,t.parking_area
+            ,pr.entrance_at
+            ,pr.exit_at
+            ,pr.status
+        FROM parking_record pr LEFT OUTER JOIN ticket t
+                     ON pr.ticket_id = t.id
+                                LEFT OUTER JOIN vip v
+                     ON pr.vip_id = v.id
+        WHERE pr.id = #{id}
+        ORDER BY entrance_at
+    </select>
+
 
 </mapper>


### PR DESCRIPTION
Notify
@sancho

Summary
주차 기록 단건 조회 기능

Motivation
프론트에서 주차 기록에서 단건 조회하는 데이터 반환요청을 받았습니다.

Description
서버의 상태를 변경하지 않고 parking record들을 가져오기 때문에 restful하게 GET 메서드를 사용하였고 url의 target resource 같은 경우에 /parking/{id}로 지정하였습니다.

요청이 들어오면 받은 식별 id를 통해 데이터를 조회하여 반환합니다. 만약 데이터가 아예 존재하지 않으면 ParkingRecordNotFoundException을 발생 시키고 해당 오류에 대한 메세지를 반환해줍니다.

InterCeptor에서 로그인 인증을 위한 경로 설정을 해주었습니다. 앞으로 기능 테스트를 위해서는 로그인을 통해 토큰을 발급받아야만 합니다.

Commits
ParkingController.java
ParkingMapper.java
ParkingService.java
InterceptorConfiguration.java
ParkingMapper.xml