### PR TITLE
로그인api 로직 리펙토링

### DIFF
--- a/src/main/java/com/ohho/valetparking/domains/member/controller/MemberController.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.ohho.valetparking.domains.member.controller;
 
+import com.ohho.valetparking.domains.member.domain.dto.SignInResponse;
 import com.ohho.valetparking.domains.member.domain.entity.Vip;
 import com.ohho.valetparking.domains.member.domain.dto.JoinRequest;
 import com.ohho.valetparking.domains.member.domain.dto.SignInRequest;
 import com.ohho.valetparking.domains.member.domain.entity.User;
 import com.ohho.valetparking.domains.member.service.MemberService;
+import com.ohho.valetparking.global.common.dto.SuccessResponse;
 import com.ohho.valetparking.global.security.JWTProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,12 +47,12 @@ public class MemberController {
     @PostMapping(value = "/member/sign-in", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity signIn(@RequestBody SignInRequest signInRequest){
 
-        memberService.signIn(signInRequest.toSignIn());
+        SignInResponse signInResponse = memberService.signIn(signInRequest.toSignIn());
 
         return ResponseEntity.ok()
                              .header("ACCESSTOKEN",jwtProvider.accessTokenCreate(signInRequest.getEmail()))
                              .header("REFRESHTOKEN","not yet")
-                             .body("로그인에 성공했습니다.");
+                             .body(SuccessResponse.success(signInResponse));
     }
 
     @PutMapping(value = "/member/password", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/ohho/valetparking/domains/member/domain/dto/SignInResponse.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/domain/dto/SignInResponse.java
@@ -1,0 +1,29 @@
+package com.ohho.valetparking.domains.member.domain.dto;
+
+import com.ohho.valetparking.domains.member.domain.entity.Member;
+import lombok.*;
+
+/**
+ * Role :
+ * Responsibility :
+ * Cooperation with :
+ **/
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
+@ToString
+public class SignInResponse {
+    private long id;
+    private String nickname;
+    private String email;
+    private int department;
+
+    public SignInResponse(Member member){
+        this.id = member.getId();
+        this.nickname = member.getNickname();
+        this.email = member.getEmail();
+        this.department = member.getDepartment();
+    }
+}

--- a/src/main/java/com/ohho/valetparking/domains/member/domain/entity/Member.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/domain/entity/Member.java
@@ -1,0 +1,26 @@
+package com.ohho.valetparking.domains.member.domain.entity;
+
+import com.ohho.valetparking.domains.member.domain.dto.SignInResponse;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Role :
+ * Responsibility :
+ * Cooperation with :
+ **/
+@AllArgsConstructor
+@ToString
+@Getter
+@EqualsAndHashCode
+public class Member {
+
+    private final long id;
+    private final String nickname;
+    private final String email;
+    private final String password;
+    private final int department;
+
+}

--- a/src/main/java/com/ohho/valetparking/domains/member/repository/MemberMapper.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/repository/MemberMapper.java
@@ -1,9 +1,6 @@
 package com.ohho.valetparking.domains.member.repository;
 
-import com.ohho.valetparking.domains.member.domain.entity.User;
-import com.ohho.valetparking.domains.member.domain.entity.Join;
-import com.ohho.valetparking.domains.member.domain.entity.LoginHistory;
-import com.ohho.valetparking.domains.member.domain.entity.Vip;
+import com.ohho.valetparking.domains.member.domain.entity.*;
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -32,4 +29,5 @@ public interface MemberMapper {
     Optional<Long> getAdminId(String email);
     List<Vip> getVip(String vipName);
 
+    Optional<Member> getMemberByEmail(String email);
 }

--- a/src/main/resources/mybatis/mapper/member/MemberMapper.xml
+++ b/src/main/resources/mybatis/mapper/member/MemberMapper.xml
@@ -69,14 +69,14 @@
                     )
     </select>
 
-    <select id="getPassword" parameterType="string" resultType="string">
-        SELECT *
+    <select id="getMemberByEmail" parameterType="string" resultType="com.ohho.valetparking.domains.member.domain.entity.Member">
+        SELECT x.id, x.nickname, x.email, x.password, x.department
             FROM(
-            SELECT password
+            SELECT *
                 FROM users
             WHERE email = #{email}
             UNION ALL
-            SELECT password
+            SELECT *
                 FROM admins
             WHERE email = #{email}) AS x
     </select>

--- a/src/test/java/com/ohho/valetparking/member/service/MemberServiceTest.java
+++ b/src/test/java/com/ohho/valetparking/member/service/MemberServiceTest.java
@@ -2,17 +2,24 @@ package com.ohho.valetparking.member.service;
 
 import com.ohho.valetparking.domains.member.domain.dto.JoinRequest;
 import com.ohho.valetparking.domains.member.domain.dto.SignInRequest;
+import com.ohho.valetparking.domains.member.domain.dto.SignInResponse;
+import com.ohho.valetparking.domains.member.domain.entity.Member;
+import com.ohho.valetparking.domains.member.domain.entity.SignIn;
 import com.ohho.valetparking.domains.member.repository.MemberMapper;
+import com.ohho.valetparking.domains.member.repository.VipMapper;
 import com.ohho.valetparking.domains.member.service.MemberService;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -25,10 +32,7 @@ import static org.mockito.Mockito.*;
 public class MemberServiceTest {
     @Mock
     MemberService memberService;
-    @Mock
-    MemberMapper memberMapper;
-    @Mock
-    PasswordEncoder passwordEncoder;
+
 
     @Test
     @DisplayName("회원가입 기능 테스트")
@@ -51,11 +55,30 @@ public class MemberServiceTest {
         //then
         assertThat(passwordEncoder.matches("test1234",test));
     }
+    @Test
+    void 로그인반환객체_컨버팅_테스트(){
+        // given
+        Member member = new Member(1L,"홍길동","test@naver.com","testpassword",0);
+        SignInResponse sign = new SignInResponse(1L,"홍길동","test@naver.com",0);
+        // when // then
+        assertThat(new SignInResponse(member)).isEqualTo(sign);
 
+    }
     @Test
     void 로그인테스트(){
+        // given
         SignInRequest sign = new SignInRequest("test@naver.com","testpassword");
-        System.out.println(sign.toSignIn());
+        Member member = new Member(1L,"홍길동","test@naver.com","testpassword",0);
+        SignInResponse signInResponse = new SignInResponse(1L,"홍길동","test@naver.com",0);
+        SignInResponse signInResponseTest = new SignInResponse(member);
+
+        // when
+        when(memberService.passwordMatch(any(SignIn.class))).thenReturn(signInResponse);
+        // then
+        assertEquals(signInResponseTest,memberService.passwordMatch(sign.toSignIn()));
     }
+
+
+
 
 }


### PR DESCRIPTION
## Notify
@Sancho

## Summary
로그인한 사용자의 사용자 정보 반환(민감정보 제외)

## Motivation
프론트엔드의 요청으로 사용자 부서 정보 반환 요청. 추후 확장 사용을 위해 로그인 사용자의 전체 정보 이름 및  부서, 이메일 까지 모두 반환


## Commits

MemberController.java
SignInResponse.java
Member.java
MemberMapper.java
MemberService.java
MemberMapper.xml
MemberServiceTest.java