### PR TITLE
Refactor : Jwt Token Ingredient Changing V2

### DIFF
--- a/src/main/java/com/ohho/valetparking/domains/parking/controller/ExitController.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/controller/ExitController.java
@@ -1,5 +1,6 @@
 package com.ohho.valetparking.domains.parking.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ohho.valetparking.domains.parking.domain.dto.ExitRequest;
 import com.ohho.valetparking.domains.parking.domain.entity.ExitForRead;
 import com.ohho.valetparking.domains.parking.service.ExitRequestService;
@@ -47,7 +48,7 @@ public class ExitController {
 
     // 권한 관리 : 관리자
     @PostMapping(value = "/exit/{id}/approve", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<SuccessResponse> requestExitApprove( @PathVariable("id") long exitRequestId, HttpServletRequest request){
+    public ResponseEntity<SuccessResponse> requestExitApprove( @PathVariable("id") long exitRequestId, HttpServletRequest request) throws JsonProcessingException {
 
         log.info("[ExitController] requestExit :::: exitRequestId ={}", exitRequestId );
         exitRequestService.approve( exitRequestId, request.getHeader("ACCESSTOKEN" ) );

--- a/src/main/java/com/ohho/valetparking/domains/parking/controller/TicketController.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/controller/TicketController.java
@@ -1,5 +1,6 @@
 package com.ohho.valetparking.domains.parking.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ohho.valetparking.domains.parking.domain.dto.TicketReqeust;
 import com.ohho.valetparking.domains.parking.domain.entity.Ticket;
 import com.ohho.valetparking.domains.parking.exception.TicketDuplicateException;
@@ -33,13 +34,12 @@ public class TicketController {
     }
 
     @PostMapping(value = "/ticket", produces = MediaType.APPLICATION_JSON_VALUE)
-    public SuccessResponse<Ticket> ticketRegister(@RequestBody @Valid TicketReqeust ticketReqeust, HttpServletRequest request){
+    public SuccessResponse<Ticket> ticketRegister(@RequestBody @Valid TicketReqeust ticketReqeust, HttpServletRequest request) throws JsonProcessingException {
         log.info("TicketController ticketReqeust ::::: = {}, Header ={} ",ticketReqeust, request.getHeader("ACCESSTOKEN"));
         Ticket ticketIncludedEmail = ticketReqeust.toTicket(
-                                             jwtProvider.getEmailInFromToken(
-                                                            request.getHeader("ACCESSTOKEN")
-                                                            )
-                                        );
+                                                         jwtProvider.getTokenIngredientFromToken(request.getHeader("ACCESSTOKEN"))
+                                                                    .getEmail()
+                                                            );
 
         ticketService.register(ticketIncludedEmail);
 

--- a/src/main/java/com/ohho/valetparking/domains/parking/service/ExitApproveService.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/service/ExitApproveService.java
@@ -1,5 +1,6 @@
 package com.ohho.valetparking.domains.parking.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ohho.valetparking.domains.member.service.MemberService;
 import com.ohho.valetparking.domains.parking.repository.ExitApproveMapper;
 import com.ohho.valetparking.global.security.jwt.JWTProvider;
@@ -31,10 +32,10 @@ public class ExitApproveService {
     }
 
     @Transactional(propagation = Propagation.REQUIRED)
-    public void approve( long exitRequestId, String accessToken ) {
+    public void approve( long exitRequestId, String accessToken ) throws JsonProcessingException {
         log.info("[ExitApproveService] approve() :: exitRequestId = {}",exitRequestId);
         // 0. jwtoken에서 Email cwk
-        String email =jwtProvider.getEmailInFromToken(accessToken);
+        String email = jwtProvider.getTokenIngredientFromToken(accessToken).getEmail();
 
         // 1. id 찾아오기
         long approveAdminId = memberService.getAdminIdByMail(email);

--- a/src/main/java/com/ohho/valetparking/domains/parking/service/ExitRequestService.java
+++ b/src/main/java/com/ohho/valetparking/domains/parking/service/ExitRequestService.java
@@ -1,5 +1,6 @@
 package com.ohho.valetparking.domains.parking.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ohho.valetparking.domains.parking.domain.entity.Exit;
 import com.ohho.valetparking.domains.parking.domain.entity.ExitForRead;
 import com.ohho.valetparking.domains.parking.domain.entity.ExitRequestStatusChange;
@@ -79,7 +80,7 @@ public class ExitRequestService {
 
 
     @Transactional
-    public void approve( long exitRequestId, String token ) {
+    public void approve( long exitRequestId, String token ) throws JsonProcessingException {
 
         // 1. 해당 요청 아이디를 가진 exit-request 테이블의 row에서 status를 승인으로 변경한다.
         ExitRequestStatusChange approveStatus = makeExitRequestStatus(exitRequestId,1);

--- a/src/main/java/com/ohho/valetparking/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/ohho/valetparking/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.ohho.valetparking.global.error;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ohho.valetparking.domains.member.exception.SignInFailException;
 import com.ohho.valetparking.domains.member.exception.SignUpFailException;
 import com.ohho.valetparking.domains.parking.exception.FailChangeExitRequestStatusException;
@@ -92,7 +93,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(FailExitRegistrationException.class)
-    protected ResponseEntity<Object> handleFailExitRegistrationException( FailExitRegistrationException ex ) {
+    protected ResponseEntity<ErrorResponse> handleFailExitRegistrationException( FailExitRegistrationException ex ) {
         log.info("GlobalExceptionHandler :: FailExitRegistrationException = {}",ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                                .body(ErrorResponse.builder()
@@ -104,7 +105,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(FailChangeExitRequestStatusException.class)
-    protected ResponseEntity<Object> handleFailChangeExitRequestStatusException( FailChangeExitRequestStatusException ex ) {
+    protected ResponseEntity<ErrorResponse> handleFailChangeExitRequestStatusException( FailChangeExitRequestStatusException ex ) {
         log.info("GlobalExceptionHandler :: FailChangeExitRequestStatusException = {}",ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                                .body(ErrorResponse.builder()
@@ -125,6 +126,17 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                              .body(ErrorResponse.builder()
                                                  .code("Reqeust Parameter")
                                                  .message(ex.getBindingResult().getAllErrors().get(0).getDefaultMessage())
+                                                 .status(HttpStatus.BAD_REQUEST)
+                                                 .build()
+                );
+    }
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleJsonProcessingException( JsonProcessingException ex) {
+        log.info("GlobalExceptionHandler :: JsonProcessingException = {}",ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                             .body(ErrorResponse.builder()
+                                                 .code("Jwt Token Binding")
+                                                 .message(ex.getMessage())
                                                  .status(HttpStatus.BAD_REQUEST)
                                                  .build()
                 );

--- a/src/main/java/com/ohho/valetparking/global/security/jwt/TokenIngredient.java
+++ b/src/main/java/com/ohho/valetparking/global/security/jwt/TokenIngredient.java
@@ -1,9 +1,6 @@
 package com.ohho.valetparking.global.security.jwt;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 /**
  * Role :
@@ -11,10 +8,12 @@ import lombok.ToString;
  * Cooperation with :
  **/
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
+@Setter
 @ToString
 @EqualsAndHashCode
 public class TokenIngredient {
-    private final String email;
-    private final int department;
+    private String email;
+    private int department;
 }

--- a/src/test/java/com/ohho/valetparking/global/common/TokenTest.java
+++ b/src/test/java/com/ohho/valetparking/global/common/TokenTest.java
@@ -59,11 +59,9 @@ public class TokenTest {
     @Test
     @DisplayName("토큰에서 객체 꺼내오기")
     void getTokenIngredient(){
+
         assertAll(
-                () -> assertThat(tesetJWTProvider.getEmailInFromToken(token)).isEqualTo("test@maver.com"),
-                () -> assertThat(tesetJWTProvider.getDepartmentInFromToken(token)).isEqualTo(0),
                 () -> assertThat(tesetJWTProvider.getTokenIngredientFromToken(token)).isEqualTo(new TokenIngredient("test@maver.com",0))
         );
-
     }
 }


### PR DESCRIPTION
### Notify
@Sancho
### Summary
토큰 생성시 객체 사용
### Motivation
토큰을 생성할 때 claim을 사용합니다. 기존에는 클레임의 재료로 primitive type을 사용했습니다. 내부 재료 변경이 있을 때 매개변수를 일일이 추가해줘야하는 비효율이 발생했습니다. 토큰의 재료를 TokenIngredient라는 객체를 만들어서 전달했습니다. 이제 재료가 변경될 때는 해당 객체에 필드만 추가해주면됩니다. 