### PR TITLE
Refactor/Gloable Exception V0.1

### DIFF
--- a/src/main/java/com/ohho/valetparking/domains/member/controller/VipApi.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/controller/VipApi.java
@@ -4,6 +4,8 @@ import com.ohho.valetparking.domains.member.domain.dto.VipRequest;
 import com.ohho.valetparking.domains.member.domain.entity.Vip;
 import com.ohho.valetparking.domains.member.service.VipService;
 import com.ohho.valetparking.global.common.dto.SuccessResponse;
+import com.ohho.valetparking.global.error.ErrorCode;
+import com.ohho.valetparking.global.error.exception.InvalidArgumentException;
 import javax.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +38,6 @@ public class VipApi {
   @PostMapping(value = "/vip", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<SuccessResponse> registor(@RequestBody @Valid VipRequest vipRequest) {
     log.info("[VipApi] :::: vipRequest = {}", vipRequest);
-
     return ResponseEntity.status(HttpStatus.OK)
         .body(SuccessResponse.success(vipService.registerVip(vipRequest)));
   }

--- a/src/main/java/com/ohho/valetparking/domains/member/exception/FailVipRegisterException.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/exception/FailVipRegisterException.java
@@ -1,13 +1,13 @@
 package com.ohho.valetparking.domains.member.exception;
 
-/**
- * Role :
- * Responsibility :
- * Cooperation with :
- **/
+import com.ohho.valetparking.global.error.exception.BaseException;
+
+
 public class FailVipRegisterException extends RuntimeException {
-    public FailVipRegisterException(){}
-    public FailVipRegisterException(String message){
-        super(message);
-    }
+
+  public FailVipRegisterException() {
+  }
+  public FailVipRegisterException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/ohho/valetparking/domains/member/exception/SignInFailException.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/exception/SignInFailException.java
@@ -1,11 +1,7 @@
 package com.ohho.valetparking.domains.member.exception;
 
-/**
- * Role :
- * Responsibility :
- * Cooperation with :
- **/
 public class SignInFailException extends RuntimeException {
+
     public SignInFailException(){}
     public SignInFailException(String message){
         super(message);

--- a/src/main/java/com/ohho/valetparking/domains/member/service/MemberService.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/service/MemberService.java
@@ -49,6 +49,7 @@ public class MemberService {
   }
 
   public void emailValidation(String email) {
+
     log.info("email = {}", email);
     if (memberMapper.mailCheck(email)) {
       throw new SignUpFailException("이메일 중복");

--- a/src/main/java/com/ohho/valetparking/domains/member/service/VipServiceV1.java
+++ b/src/main/java/com/ohho/valetparking/domains/member/service/VipServiceV1.java
@@ -4,7 +4,6 @@ import com.ohho.valetparking.domains.member.domain.dto.VipRequest;
 import com.ohho.valetparking.domains.member.domain.entity.Vip;
 import com.ohho.valetparking.domains.member.exception.FailVipRegisterException;
 import com.ohho.valetparking.domains.member.repository.VipMapper;
-import com.ohho.valetparking.domains.parking.exception.FailChangeExitRequestStatusException;
 import com.ohho.valetparking.global.common.dto.SuccessResponse;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/ohho/valetparking/global/common/dto/ApiResponse.java
+++ b/src/main/java/com/ohho/valetparking/global/common/dto/ApiResponse.java
@@ -1,0 +1,73 @@
+package com.ohho.valetparking.global.common.dto;
+
+import com.ohho.valetparking.global.error.ErrorCode;
+import com.ohho.valetparking.global.error.ErrorResponse;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Role : 모든 반환 값을 대신한다. Responsibility : 내부에 errorResponse를 등록해야할 것인가에 대한 고민이 더 필요 httpstatus는 스프링에
+ * 종속 적이다. 그래서 code와 status의 경우는 그냥 만들어서 사용 success는 그냥 200 ok이다.
+ **/
+@ToString
+@Getter
+@EqualsAndHashCode
+public class ApiResponse<T> {
+
+  @DateTimeFormat(pattern = "yyyy-MM-dd 'T'HH:mm")
+  private final String localDateTime;
+  private final boolean success;
+  private final T data;
+
+  public ApiResponse(boolean success, T data) {
+    localDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+    this.success = success;
+    this.data = data;
+  }
+
+  public static <T> ApiResponse success(T data) {
+    return new ApiResponse(true, data);
+  }
+
+  public static ApiResponse fail(ErrorCode errorCode) {
+    return new ApiResponse(false, new ErrorBody(errorCode.getCode(), errorCode.getStatus(),
+        errorCode.getMessage()));
+  }
+  public static ApiResponse fail(ErrorCode errorCode, String message) {
+    return new ApiResponse(false, new ErrorBody(errorCode.getCode(), errorCode.getStatus(),
+        message));
+  }
+  @ToString
+  @EqualsAndHashCode
+  public static final class ErrorBody {
+
+    private final String code;
+    private final int status;
+    private final String message;
+
+    public ErrorBody(String code, int status, String message) {
+      this.status = status;
+      this.code = code;
+      this.message = message;
+    }
+
+    public int getStatus() {
+      return this.status;
+    }
+
+    public String getCode() {
+      return code;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+  }
+}
+

--- a/src/main/java/com/ohho/valetparking/global/error/ErrorCode.java
+++ b/src/main/java/com/ohho/valetparking/global/error/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.ohho.valetparking.global.error;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 /**
  * Role :
@@ -11,18 +12,19 @@ import lombok.Getter;
 public enum ErrorCode {
 
     // Common
-    INVALID_INPUT_VALUE(400, "C001", " Invalid Input Value"),
-    METHOD_NOT_ALLOWED(405, "C002", " Invalid Input Value"),
-    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied"),
+    INVALID_ARGUMENT(400, "C001", "잘못된 입력값입니다."),
+    METHOD_NOT_ALLOWED(405, "C002", "기능 사용 권한이 없습니다."),
+    HANDLE_ACCESS_DENIED(403, "C006", "권한이 없습니다."),
 
     // Member
-    EMAIL_DUPLICATION(400, "M001", "Email is Duplication"),
-    LOGIN_INPUT_INVALID(400, "M002", "Login input is invalid")
+    EMAIL_DUPLICATION(400, "M001", "중복된 이메일이 존재합니다."),
+    LOGIN_INPUT_INVALID(400, "M002", "로그인 정보가 없습니다.")
 
     ;
+    private final int status;
     private final String code;
     private final String message;
-    private int status;
+
 
     ErrorCode(final int status, final String code, final String message) {
         this.status = status;

--- a/src/main/java/com/ohho/valetparking/global/error/ErrorResponse.java
+++ b/src/main/java/com/ohho/valetparking/global/error/ErrorResponse.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import org.springframework.http.ResponseEntity;
 
 
 @Getter // 시리얼라이즈가 필요한 객체일 경우에는 Getter 메서드가 꼭 필요하다.
@@ -56,4 +57,5 @@ public class ErrorResponse {
             return new ErrorResponse(this);
         }
     }
+
 }

--- a/src/main/java/com/ohho/valetparking/global/error/exception/BaseException.java
+++ b/src/main/java/com/ohho/valetparking/global/error/exception/BaseException.java
@@ -1,0 +1,27 @@
+package com.ohho.valetparking.global.error.exception;
+
+import com.ohho.valetparking.global.error.ErrorCode;
+
+/**
+ * @explain System전체에서 사용할 최상위 커스텀 예외
+ * @HOWTO 모든 커스텀 예외는 이 예외를 확장해서 사용할 것.
+ * @Spec ErrorCode를 사용함으로 에러 코드로 모든 설명을 하게됨.
+ **/
+public class BaseException extends RuntimeException {
+
+  private ErrorCode errorCode;
+
+  public BaseException(String message, ErrorCode errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public BaseException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+  public BaseException(){}
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+}

--- a/src/main/java/com/ohho/valetparking/global/error/exception/InvalidArgumentException.java
+++ b/src/main/java/com/ohho/valetparking/global/error/exception/InvalidArgumentException.java
@@ -1,0 +1,21 @@
+package com.ohho.valetparking.global.error.exception;
+
+
+import com.ohho.valetparking.global.error.ErrorCode;
+
+/**
+ * Role : Responsibility : Cooperation with :
+ **/
+public class InvalidArgumentException extends BaseException {
+
+  public InvalidArgumentException(String message, ErrorCode errorCode) {
+    super(message, errorCode);
+  }
+
+  public InvalidArgumentException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public InvalidArgumentException() {
+  }
+}

--- a/src/test/java/com/ohho/valetparking/global/ExceptionTest.java
+++ b/src/test/java/com/ohho/valetparking/global/ExceptionTest.java
@@ -1,0 +1,105 @@
+package com.ohho.valetparking.global;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ohho.valetparking.domains.member.controller.VipApi;
+import com.ohho.valetparking.domains.member.service.VipService;
+import com.ohho.valetparking.global.common.dto.ApiResponse;
+import com.ohho.valetparking.global.common.dto.ApiResponse.ErrorBody;
+import com.ohho.valetparking.global.configuration.InterceptorConfiguration;
+import com.ohho.valetparking.global.error.ErrorCode;
+import com.ohho.valetparking.global.error.exception.BaseException;
+import com.ohho.valetparking.global.error.exception.InvalidArgumentException;
+import com.ohho.valetparking.global.security.jwt.JWTProvider;
+import java.util.Collection;
+import java.util.Objects;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+/**
+ * Role : Responsibility : Cooperation with :
+ **/
+@WebMvcTest(controllers = {VipApi.class}
+    , excludeAutoConfiguration = SecurityAutoConfiguration.class
+    , excludeFilters = {
+    @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = InterceptorConfiguration.class)})
+@ExtendWith(MockitoExtension.class)
+public class ExceptionTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  VipService vipService;
+
+  @MockBean
+  JWTProvider jwtProvider;
+
+  @MockBean
+  VipApi vipApi;
+
+  @Test
+  @DisplayName("BaseException 메세지 테스트입니다.")
+  void baseExceptionMessageTest() {
+    // given
+    BaseException baseException = new BaseException(ErrorCode.INVALID_ARGUMENT);
+    // when
+    assertAll(
+        () -> assertThat("잘못된 입력값입니다.").isEqualTo(baseException.getMessage()),
+        () -> assertThat("잘못된 입력값입니다.").isEqualTo(baseException.getErrorCode().getMessage()),
+        () -> assertThat("C001").isEqualTo(baseException.getErrorCode().getCode()),
+        () -> assertThat(400).isEqualTo(baseException.getErrorCode().getStatus())
+    );
+  }
+
+  @Test
+  @DisplayName("BaseException을 확장한 예외 객체 테스트입니다. ErrorCode만 이용한 경우")
+  void ExtnedsbaseExceptionMessageTest() {
+    // given
+    BaseException baseException = new InvalidArgumentException(ErrorCode.INVALID_ARGUMENT);
+    // when
+    assertAll(
+        () -> assertThat("잘못된 입력값입니다.").isEqualTo(baseException.getMessage()),
+        () -> assertThat("잘못된 입력값입니다.").isEqualTo(baseException.getErrorCode().getMessage()),
+        () -> assertThat("C001").isEqualTo(baseException.getErrorCode().getCode()),
+        () -> assertThat(400).isEqualTo(baseException.getErrorCode().getStatus())
+    );
+  }
+
+  @Test
+  @DisplayName("반환 api 예외 발생 테스트. 직접 입력한 메세지를 입력하는 경우")
+  void apiResponseWithExceptionObjectTest() {
+    // given
+    BaseException baseException = new InvalidArgumentException("테스트입니다.",ErrorCode.INVALID_ARGUMENT);
+    ApiResponse apiResponse = ApiResponse.fail(baseException.getErrorCode(),baseException.getMessage());
+
+    // when
+    ErrorBody errorBody = (ErrorBody) apiResponse.getData();
+
+    // then
+    assertAll(
+        () -> assertThat("테스트입니다.").isEqualTo(errorBody.getMessage()),
+        () -> assertThat("C001").isEqualTo(errorBody.getCode()),
+        () -> assertThat(400).isEqualTo(errorBody.getStatus())
+    );
+  }
+}

--- a/src/test/java/com/ohho/valetparking/parking/TicketControllerTest.java
+++ b/src/test/java/com/ohho/valetparking/parking/TicketControllerTest.java
@@ -18,8 +18,6 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -27,7 +25,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import static java.lang.Thread.sleep;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;


### PR DESCRIPTION
## Notify
@Sancho

## Summary
ExceptionHandler 중복 줄이기 V 0.1

## Motivation
프로젝트 코드를 작성하다가 새로운 예외가 필요했습니다. 예외 객체를 만들고 전역에서 발생하는 Exception을 처리하는 클래스에 예외를 추가하려하는데 스크롤을 한도 끝도 없이 내려야했습니다. 마지막 라인을 보는데 212라인이었고 리펙토링의 필요성을 느껴 리펙토링을 진행했습니다. 

## Description
ErrorCode(Enum)를 만듭니다. 이 코드는 status와 도메인 범주를 의미하는 코드, 메세지 세가지를 추가로 가지고있습니다. 
ApiResponse를 새로하나 만듭니다. -- 기존에는 실패와 성공 response가 따로 있었습니다. 이를 합치기 위함입니다.
RuntimeException을 확장한 최상위 커스텀 클래스를 만듭니다. 그리고 이 객체는 ErrorCode를 가지고 있습니다. 
이제 최상위 커스텀 클래스를 확장한 커스텀 클래스들을 만들겁니다.( 범주를 발생상황별로 두려고합니다. InvalidArgument,InvalidToken 등)

## Commits
ApiResponse.java
BaseException.java
InvalidArgumentException.java
ExceptionTest.java
